### PR TITLE
Fix IndexError problem of birrtPlanner.py

### DIFF
--- a/sbp_env/planners/birrtPlanner.py
+++ b/sbp_env/planners/birrtPlanner.py
@@ -80,7 +80,7 @@ class BiRRTPlanner(RRTPlanner):
                     other_poses = self.poses
                     other_nodes = self.nodes
                 distances = np.linalg.norm(
-                    other_poses[: len(self.nodes)] - newpos, axis=1
+                    other_poses[: len(other_nodes)] - newpos, axis=1
                 )
                 if min(distances) < self.args.epsilon:
                     idx = np.argmin(distances)


### PR DESCRIPTION
It could happen that `idx` variable calculated in line 86 is out of range for `other_nodes` list when `self.goal_tree_turn` is set to False.